### PR TITLE
Promote household member to head of a new household

### DIFF
--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/CmtRelationshipTEIDataPresenter.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/CmtRelationshipTEIDataPresenter.kt
@@ -107,7 +107,8 @@ class CmtRelationshipTEIDataPresenter(
                                 relatedProgramName = relationship.relatedProgram.teiTypeName,
                                 relatedProgramUid = relationship.relatedProgram.programUid,
                                 maxCount = relationship.maxCount,
-                                supportsHeadPromotion = relationship.headAttribute != null
+                                supportsHeadPromotion = relationship.headAttribute != null,
+                                supportsNewHouseholdPromotion = relationship.parentRelationshipType != null
                             )
                         }
                 }
@@ -373,6 +374,50 @@ class CmtRelationshipTEIDataPresenter(
                             Timber.d("Promoted $uid to household head")
                             retrieveRelationships()
                             view.refreshDashboardHeader()
+                        }.onFailure { Timber.e(it) }
+                    },
+                    { Timber.e(it) }
+                )
+        )
+    }
+
+    fun onPromoteToNewHousehold(type: String, uid: String) {
+        view.confirmPromoteToNewHousehold(type, uid)
+    }
+
+    fun promoteToNewHousehold(type: String, uid: String) {
+        val relationship = relationshipsConfig.firstOrNull { it.access.targetRelationshipUid == type }
+            ?: return
+        val parentRelationshipType = relationship.parentRelationshipType ?: return
+        val parentTeiUid = relationships.value
+            ?.find { it.uid == parentRelationshipType }
+            ?.relatedTeis?.firstOrNull()?.uid
+            ?: return
+
+        val attributeToIncrement = workflowConfig.autoIncrementAttributes
+            .find { it.programUid == relationship.access.targetProgramUid }
+            ?.attributeUid
+
+        compositeDisposable.add(
+            Single.fromCallable {
+                relationshipRepository.promoteToNewHousehold(
+                    membershipRelationship = relationship,
+                    parentRelationshipType = parentRelationshipType,
+                    parentTeiUid = parentTeiUid,
+                    targetProgram = relationship.access.targetProgramUid,
+                    targetTeiType = relationship.access.targetTeiTypeUid,
+                    autoIncrementAttribute = attributeToIncrement,
+                    oldHouseholdTeiUid = teiUid,
+                    memberTeiUid = uid
+                )
+            }.subscribeOn(schedulerProvider.io())
+                .observeOn(schedulerProvider.ui())
+                .subscribe(
+                    { result ->
+                        result.onSuccess { (newHouseholdUid, enrollmentUid) ->
+                            Timber.d("Promoted $uid to head of new household $newHouseholdUid")
+                            retrieveRelationships()
+                            view.goToTeiDashboard(newHouseholdUid, relationship.access.targetProgramUid, enrollmentUid)
                         }.onFailure { Timber.e(it) }
                     },
                     { Timber.e(it) }

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataContracts.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataContracts.kt
@@ -83,11 +83,16 @@ class TEIDataContracts {
         )
 
         fun goToEnrollment(programUid: String, enrollmentUid: String,)
+        fun goToTeiDashboard(teiUid: String, programUid: String, enrollmentUid: String)
         fun confirmRelationshipRemove(
             type: String,
             teiUid: String
         )
         fun confirmPromoteToHead(
+            type: String,
+            teiUid: String
+        )
+        fun confirmPromoteToNewHousehold(
             type: String,
             teiUid: String
         )

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataFragment.kt
@@ -384,6 +384,9 @@ class TEIDataFragment :
                     },
                     onPromoteToHead = { type, uid ->
                         cmtPresenter.onPromoteToHead(type, uid)
+                    },
+                    onPromoteToNewHousehold = { type, uid ->
+                        cmtPresenter.onPromoteToNewHousehold(type, uid)
                     }
                 )
             }
@@ -800,6 +803,21 @@ class TEIDataFragment :
         dashboardActivity.executeOnUIThread()
     }
 
+    override fun goToTeiDashboard(
+        teiUid: String,
+        programUid: String,
+        enrollmentUid: String,
+    ) {
+        requireActivity().startActivity(
+            TeiDashboardMobileActivity.intent(
+                requireContext(),
+                teiUid,
+                programUid,
+                enrollmentUid,
+            ),
+        )
+    }
+
     override fun goToEnrollment(
         programUid: String,
         enrollmentUid: String,
@@ -848,6 +866,26 @@ class TEIDataFragment :
         val dialog = BottomSheetDialog(
             bottomSheetDialogUiModel,
             { cmtPresenter.promoteToHead(type, teiUid) },
+            { /*Unused*/ },
+
+        )
+        dialog.show(parentFragmentManager, AlertBottomDialog::class.java.simpleName)
+    }
+
+    override fun confirmPromoteToNewHousehold(
+        type: String,
+        teiUid: String
+    ) {
+        val bottomSheetDialogUiModel = BottomSheetDialogUiModel(
+            title = "Move to New Household",
+            message = "Are you sure you want to move this person to a new household? A new household will be created for them as its head, their details will be copied onto it, and they will be removed from this household.",
+            iconResource = R.drawable.ic_question_positive,
+            mainButton = MainButton(R.string.yes),
+            secondaryButton = DialogButtonStyle.SecondaryButton(R.string.no),
+        )
+        val dialog = BottomSheetDialog(
+            bottomSheetDialogUiModel,
+            { cmtPresenter.promoteToNewHousehold(type, teiUid) },
             { /*Unused*/ },
 
         )

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/ui/TeiDetailDashboard.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/ui/TeiDetailDashboard.kt
@@ -38,6 +38,7 @@ fun TeiDetailDashboard(
     onCreateEntity: (String, String) -> Unit,
     onRemoveRelationship: (String, String) -> Unit,
     onPromoteToHead: (String, String) -> Unit,
+    onPromoteToNewHousehold: (String, String) -> Unit,
     quickActions: List<QuickActionUiModel>,
     modifier: Modifier = Modifier,
     isGrouped: Boolean = true,
@@ -90,7 +91,8 @@ fun TeiDetailDashboard(
                 onEntitySelect = onEntitySelected,
                 onCreateEntity = onCreateEntity,
                 removeRelationship = onRemoveRelationship,
-                onPromoteToHead = onPromoteToHead
+                onPromoteToHead = onPromoteToHead,
+                onPromoteToNewHousehold = onPromoteToNewHousehold
             )
         }
 

--- a/community/src/main/java/org/dhis2/community/relationships/CmtRelationshipViewModel.kt
+++ b/community/src/main/java/org/dhis2/community/relationships/CmtRelationshipViewModel.kt
@@ -22,7 +22,8 @@ data class CmtRelationshipTypeViewModel(
     val relatedProgramUid: String,
     val relatedTeis: List<CmtRelationshipViewModel>,
     val maxCount: Int = Int.MAX_VALUE,
-    val supportsHeadPromotion: Boolean = false
+    val supportsHeadPromotion: Boolean = false,
+    val supportsNewHouseholdPromotion: Boolean = false
 ) {
 
 }

--- a/community/src/main/java/org/dhis2/community/relationships/RelationshipConfigModel.kt
+++ b/community/src/main/java/org/dhis2/community/relationships/RelationshipConfigModel.kt
@@ -13,6 +13,7 @@ data class Relationship(
     val attributeMappings: List<AttributeMapping> = emptyList(),
     val headAttribute: String? = null,
     val headPromotionAttributes: List<AttributeMapping> = emptyList(),
+    val parentRelationshipType: String? = null,
 )
 
 data class Access(

--- a/community/src/main/java/org/dhis2/community/relationships/RelationshipRepository.kt
+++ b/community/src/main/java/org/dhis2/community/relationships/RelationshipRepository.kt
@@ -430,6 +430,106 @@ class RelationshipRepository(
         }
     }
 
+    fun promoteToNewHousehold(
+        membershipRelationship: org.dhis2.community.relationships.Relationship,
+        parentRelationshipType: String,
+        parentTeiUid: String,
+        targetProgram: String,
+        targetTeiType: String,
+        autoIncrementAttribute: String?,
+        oldHouseholdTeiUid: String,
+        memberTeiUid: String
+    ): Result<Pair<String, String>> {
+        return try {
+            val orgUnit = d2.trackedEntityModule()
+                .trackedEntityInstances()
+                .uid(oldHouseholdTeiUid)
+                .blockingGet()
+                ?.organisationUnit()
+                ?: throw IllegalStateException("Organisation unit not found for household $oldHouseholdTeiUid")
+
+            val newHouseholdUid = d2.trackedEntityModule().trackedEntityInstances().blockingAdd(
+                TrackedEntityInstanceCreateProjection.builder()
+                    .organisationUnit(orgUnit)
+                    .trackedEntityType(targetTeiType)
+                    .build()
+            )
+
+            val enrollmentUid = d2.enrollmentModule().enrollments().blockingAdd(
+                EnrollmentCreateProjection.builder()
+                    .trackedEntityInstance(newHouseholdUid)
+                    .program(targetProgram)
+                    .organisationUnit(orgUnit)
+                    .build()
+            )
+            d2.enrollmentModule().enrollments().uid(enrollmentUid).setEnrollmentDate(Date())
+            d2.enrollmentModule().enrollments().uid(enrollmentUid).setIncidentDate(Date())
+
+            // Same identity attributes used for in-place head promotion, copied
+            // member -> new household instead of member -> existing household.
+            applyAttributeMappings(
+                sourceTeiUid = memberTeiUid,
+                targetTeiUid = newHouseholdUid,
+                mappings = membershipRelationship.headPromotionAttributes.mapNotNull { mapping ->
+                    val householdAttribute = mapping.sourceAttribute
+                    if (householdAttribute.isNullOrBlank()) {
+                        null
+                    } else {
+                        AttributeMapping(
+                            sourceAttribute = mapping.targetAttribute,
+                            targetAttribute = householdAttribute,
+                            defaultValue = null
+                        )
+                    }
+                }
+            )
+
+            if (autoIncrementAttribute != null) {
+                val siblingCount = d2.relationshipModule().relationships()
+                    .byRelationshipType().eq(parentRelationshipType)
+                    .byItem(RelationshipHelper.teiItem(parentTeiUid))
+                    .blockingGetUids()
+                    .size
+                d2.trackedEntityModule().trackedEntityAttributeValues()
+                    .value(autoIncrementAttribute, newHouseholdUid)
+                    .blockingSet((siblingCount + 1).toString())
+            }
+
+            // Attach the new household to the same parent (Community) as the old one
+            createAndAddRelationship(
+                selectedTeiUid = parentTeiUid,
+                relationshipTypeUid = parentRelationshipType,
+                teiUid = newHouseholdUid,
+                relationshipSide = RelationshipConstraintSide.FROM
+            ).getOrThrow()
+
+            // Move the member: drop the old household link, attach to the new one
+            deleteRelationship(
+                relationshipType = membershipRelationship.access.targetRelationshipUid,
+                teiUid = oldHouseholdTeiUid,
+                relatedTeiUid = memberTeiUid
+            ).getOrThrow()
+
+            createAndAddRelationship(
+                selectedTeiUid = memberTeiUid,
+                relationshipTypeUid = membershipRelationship.access.targetRelationshipUid,
+                teiUid = newHouseholdUid,
+                relationshipSide = RelationshipConstraintSide.FROM
+            ).getOrThrow()
+
+            membershipRelationship.headAttribute?.let { headAttribute ->
+                d2.trackedEntityModule().trackedEntityAttributeValues()
+                    .value(headAttribute, memberTeiUid)
+                    .blockingSet("true")
+            }
+
+            Result.success(newHouseholdUid to enrollmentUid)
+        } catch (error: Exception) {
+            Timber.e(error, "Error promoting TEI to head of a new household")
+            Result.failure(error)
+        }
+    }
+
     private fun applyAttributeMappings(
         sourceTeiUid: String,
         targetTeiUid: String,

--- a/community/src/main/java/org/dhis2/community/relationships/ui/components/CollapsibleRelationshipSection.kt
+++ b/community/src/main/java/org/dhis2/community/relationships/ui/components/CollapsibleRelationshipSection.kt
@@ -89,7 +89,8 @@ fun CollapsibleRelationshipSection(
     removeRelationship: (String, String) -> Unit = {_,_ -> },
     onCreateEntity: (String, String) -> Unit = { _, _ -> },
     onSearchTEIs: (String, String) -> Unit = { _, _ -> },
-    onPromoteToHead: (String, String) -> Unit = { _, _ -> }
+    onPromoteToHead: (String, String) -> Unit = { _, _ -> },
+    onPromoteToNewHousehold: (String, String) -> Unit = { _, _ -> }
 ) {
     Dhis2CmtTheme {
         CollapsibleRelationshipSectionContent(
@@ -100,7 +101,8 @@ fun CollapsibleRelationshipSection(
             removeRelationship = removeRelationship,
             onCreateEntity = onCreateEntity,
             onSearchTEIs = onSearchTEIs,
-            onPromoteToHead = onPromoteToHead
+            onPromoteToHead = onPromoteToHead,
+            onPromoteToNewHousehold = onPromoteToNewHousehold
         )
     }
 }
@@ -118,7 +120,8 @@ private fun CollapsibleRelationshipSectionContent(
     removeRelationship: (String, String) -> Unit = {_, _ -> },
     onCreateEntity: (String, String) -> Unit = { _, _ -> },
     onSearchTEIs: (String, String) -> Unit = { _, _ -> },
-    onPromoteToHead: (String, String) -> Unit = { _, _ -> }
+    onPromoteToHead: (String, String) -> Unit = { _, _ -> },
+    onPromoteToNewHousehold: (String, String) -> Unit = { _, _ -> }
 ) {
     val title = relationshipTypeView.description
     val existingRelationships = relationshipTypeView.relatedTeis
@@ -271,7 +274,9 @@ private fun CollapsibleRelationshipSectionContent(
                                 onClick = { onRelationshipClick(rel) },
                                 removeRelationship = { removeRelationship(relationshipTypeView.uid, rel.uid) },
                                 canPromote = relationshipTypeView.supportsHeadPromotion,
-                                onPromote = { onPromoteToHead(relationshipTypeView.uid, rel.uid) }
+                                onPromote = { onPromoteToHead(relationshipTypeView.uid, rel.uid) },
+                                canPromoteToNewHousehold = relationshipTypeView.supportsNewHouseholdPromotion,
+                                onPromoteToNewHousehold = { onPromoteToNewHousehold(relationshipTypeView.uid, rel.uid) }
                             )
                             Divider(color = MaterialTheme.colorScheme.outlineVariant)
                         }
@@ -371,7 +376,9 @@ private fun RelationshipItem(
     isSelection: Boolean = false,
     removeRelationship: () -> Unit = {},
     canPromote: Boolean = false,
-    onPromote: () -> Unit = {}
+    onPromote: () -> Unit = {},
+    canPromoteToNewHousehold: Boolean = false,
+    onPromoteToNewHousehold: () -> Unit = {}
 ) {
     val tieTypeIcon = res.getObjectStyleDrawableResource(item.iconName, R.drawable.ic_tei_default)
 
@@ -457,6 +464,21 @@ private fun RelationshipItem(
                             onClick = {
                                 showMenu = false
                                 onPromote()
+                            }
+                        )
+                    }
+                    if (canPromoteToNewHousehold && !item.isHead) {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    "Move to New Household",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                            },
+                            onClick = {
+                                showMenu = false
+                                onPromoteToNewHousehold()
                             }
                         )
                     }


### PR DESCRIPTION
### Summary                                                                                                                                                                                               
                                                                                                                                                                                                        
  - Lets a non-head household member be split off into their own brand-new household: creates the new Household TEI in the same org unit, auto-increments its code (numbered within the same parent     
  Community), copies the member's identity attributes onto it (reusing the existing headPromotionAttributes), attaches it to that same Community, and moves the member's membership over as its head.   
  - Adds Relationship.parentRelationshipType to the relationships dataStore config — points at the relationship entry linking a household to its parent Community, so the new household can be attached 
  to the right one.                                                                                                                                                                                     
  - New "Move to New Household" action in the members list, alongside the existing "Set as Household Head". Both are hidden for whoever currently holds head — a head must be demoted (via the existing 
  promote-to-head action) before they're eligible to found their own household.                                                                                                                         
  - On success, navigates straight to the new household's TEI dashboard (reusing the same navigation already used for tapping a relationship item), rather than its enrollment form.                    
                                                                                                                                                                                                        
  Config change                                                                                                                                                                                
                                                                                                                                                                                                        
  Added parentRelationshipType to the "Members" entry in the relationships dataStore key (namespace community_redesign), pointing at the targetRelationshipUid of the household↔Community relationship  
  entry:                                                                                                                                                                                                
  "parentRelationshipType": "wcSMItGpTjL"                                                                                                                                                               
  No other config or metadata changes were needed — org unit, target program/TEI type, and the auto-increment attribute are all resolved from existing config.                                              
                                                                                                                                                                                                        
 ### Test plan                                                                                                                                                                                             
                                                                                                                                                                                                        
  - [ ] ./gradlew :community:compileDebugKotlin :app:compileDhis2DebugKotlin                                                                                                                            
  - [ ] Add parentRelationshipType to the live relationships dataStore config                                                                                                                           
  - [ ] On a household with 2+ members, confirm "Move to New Household" is hidden for the current head                                                                                                  
  - [ ] Promote a different member to head (existing feature), confirm the former head becomes eligible for "Move to New Household"                                                                     
  - [ ] Use "Move to New Household" on them; confirm a new household is created with an incremented code, the copied identity attributes, attached to the same Community, and that the member disappears
  from the old household's Members list                                                                                                                                                                 
  - [ ] Confirm the app navigates to the new household's TEI dashboard afterward  